### PR TITLE
Fix add support for plain-text header format and CORS error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ load_dotenv()
 app = Flask(__name__)
 CORS(app, resources={
     r"/*" : {
-        "origins": [os.getenv('FRONTEND_URL')],
+        "origins": [os.getenv('FRONTEND_URL', 'http://localhost:5173')],
         "methods" : ["POST", "GET"],
         
     }

--- a/backend/ytm.py
+++ b/backend/ytm.py
@@ -3,6 +3,67 @@ import ytmusicapi
 from spotify import get_all_tracks, get_playlist_name
 
 
+def parse_headers(headers_text):
+    """
+    Convert headers from plain text format to proper HTTP header format.
+    Supports both formats:
+    - Standard format: "header: value"
+    - Plain format: "header\\nvalue\\nheader2\\nvalue2"
+    """
+    if not headers_text or not headers_text.strip():
+        raise Exception("Headers cannot be empty")
+    
+    lines = [line.strip() for line in headers_text.strip().split('\n') if line.strip()]
+    
+    # Check if headers are already in correct format
+    first_line = lines[0] if lines else ""
+    colon_pos = first_line.find(': ')
+    
+    if colon_pos > 0 and colon_pos < 50:
+        return headers_text
+    
+    # Filter out the "Decoded:" section - skip lines that are part of decoded content
+    cleaned_lines = []
+    skip_mode = False
+    
+    for line in lines:
+        # Start skipping when we hit "Decoded:"
+        if line == 'Decoded:':
+            skip_mode = True
+            continue
+        
+        # Skip lines that look like decoded protobuf content
+        if skip_mode:
+            # These are characteristics of the decoded section
+            if (line.startswith('message ') or 
+                line.startswith('//') or 
+                line.startswith('repeated ') or
+                line == '}' or
+                line.startswith('int32 ') or
+                '{' in line):
+                continue
+            else:
+                # Looks like a real header again, stop skipping
+                skip_mode = False
+        
+        if not skip_mode:
+            cleaned_lines.append(line)
+    
+    lines = cleaned_lines
+    
+    if len(lines) % 2 != 0:
+        raise Exception(f"Invalid headers format. Each header name must have a corresponding value. Got {len(lines)} lines (should be even). Last line: '{lines[-1] if lines else 'none'}'")
+    
+    formatted_headers = []
+    for i in range(0, len(lines), 2):
+        header_name = lines[i]
+        header_value = lines[i + 1]
+        formatted_line = f"{header_name}: {header_value}"
+        formatted_headers.append(formatted_line)
+    
+    return '\n'.join(formatted_headers)
+
+
 def get_video_ids(ytmusic,tracks):
     video_ids = []
     missed_tracks = {
@@ -25,11 +86,18 @@ def get_video_ids(ytmusic,tracks):
 
 
 def create_ytm_playlist(playlist_link, headers):
-    ytmusicapi.setup(filepath="header_auth.json", headers_raw=headers)
+    try:
+        # Parse and format headers
+        formatted_headers = parse_headers(headers)
+        ytmusicapi.setup(filepath="header_auth.json", headers_raw=formatted_headers)
+    except Exception as e:
+        raise Exception(f"Failed to setup YouTube Music API: {str(e)}")
+    
     ytmusic = YTMusic("header_auth.json")
     tracks = get_all_tracks(playlist_link, "IN")
     name = get_playlist_name(playlist_link)
     video_ids, missed_tracks = get_video_ids(ytmusic, tracks)
     ytmusic.create_playlist(name, "", "PRIVATE", video_ids)
+    print(f"Creating YouTube Music playlist: {name} with {len(video_ids)} songs")
     return missed_tracks
 


### PR DESCRIPTION
**Problem:**
- YouTube Music headers copied from Chrome DevTools in plain text format (alternating lines) were not supported
- Flask server crashed with `TypeError: argument of type 'NoneType' is not iterable` when `FRONTEND_URL` environment variable was not set

**Solution:**
- Implemented `parse_headers()` function that automatically detects and converts both header formats:
  - Standard format: `header: value`
  - Plain text format: `header\nvalue\nheader2\nvalue2`
- Added logic to skip Chrome's "Decoded:" protobuf section when parsing headers
- Added fallback to `http://localhost:5173` for `FRONTEND_URL` in CORS configuration

**Result:**
Users can now copy request headers directly from Chrome DevTools without manual formatting, improving the setup experience.