### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 SpotTransfer lets you instantly migrate any Spotify playlist to YouTube Music—no manual copy-pasting needed.
 
-[![](https://api.star-history.com/svg?repos=Pushan2005/SpotTransfer&type=date&legend=top-left)](https://www.star-history.com/#Pushan2005/SpotTransfer&type=date&legend=top-left)
-
-<!-- start history service seems to be down -->
+[![](https://star-history.dera.page/svg?repos=Pushan2005/SpotTransfer&type=date&legend=top-left)](https://star-history.dera.page/#Pushan2005/SpotTransfer&type=date&legend=top-left)
 
 ## Quick Start
 


### PR DESCRIPTION
The star history chart in the README was not rendering because the underlying service stopped working due to GitHub stargazer API restrictions. This PR points the chart at a working alternative so the chart is visible again.